### PR TITLE
fix: improve 'Large Album Art Viewer' interaction events

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -358,6 +358,15 @@ impl eframe::App for AudioConverterApp {
 
         if !self.app_state.table_selections.is_empty() {
             ui::file_info::file_info_popup(&mut self.app_state, ctx);
+
+            if self.app_state.showing_lg_art {
+                egui::Area::new(egui::Id::new("viewer"))
+                    .order(egui::Order::Foreground)
+                    .show(ctx, |ui| {
+                        let _ = ui.allocate_rect(ctx.content_rect(), egui::Sense::click_and_drag());
+                        ui::album_art_viewer::large_album_art_viewer(&mut self.app_state, ctx);
+                    });
+            }
         }
 
         self.preview_dropped_files(ctx);

--- a/src/ui/album_art_viewer.rs
+++ b/src/ui/album_art_viewer.rs
@@ -13,10 +13,6 @@ pub fn large_album_art_viewer(state: &mut AppState, ctx: &egui::Context) {
         state.lg_cover_art = None;
     }
 
-    if !state.showing_lg_art {
-        return;
-    }
-
     let painter = ctx.layer_painter(LayerId::new(
         Order::Foreground,
         Id::new("large_album_art_viewer"),
@@ -70,7 +66,7 @@ pub fn large_album_art_viewer(state: &mut AppState, ctx: &egui::Context) {
             Color32::WHITE,
         );
 
-        let clicked_on_art = ctx.input(|i| i.pointer.any_click())
+        let clicked_on_art = ctx.input(|i| i.pointer.any_pressed())
             && !dest_rect.contains(ctx.input(|i| i.pointer.interact_pos()).unwrap());
         if clicked_on_art {
             state.showing_lg_art = false;

--- a/src/ui/file_info.rs
+++ b/src/ui/file_info.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc;
 
 use egui::{Sense, Vec2};
 
-use crate::{app::AppState, ui::album_art_viewer::large_album_art_viewer};
+use crate::app::AppState;
 
 pub fn file_info_popup(state: &mut AppState, ctx: &egui::Context) {
     use egui::Align2;
@@ -92,6 +92,4 @@ pub fn file_info_popup(state: &mut AppState, ctx: &egui::Context) {
                 }
             }
         });
-
-    large_album_art_viewer(state, ctx);
 }


### PR DESCRIPTION
Closes #25 

- Click off art to close viewer
- Consume mouse inputs (preventing lower layers from being interacted with)